### PR TITLE
API sends a 404 when invalid API route is requested

### DIFF
--- a/backend/controllers/static.js
+++ b/backend/controllers/static.js
@@ -10,3 +10,10 @@ module.exports.status = (req, res) => {
 module.exports.getAll = (req, res) => {
 	return res.sendFile(path.join(__dirname, '../../', 'public/index.html'));
 };
+
+module.exports.apiError = (req, res) => {
+	return res.status(404).json({
+		status: 'error',
+		message: 'Invalid API route',
+	});
+};

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -56,6 +56,8 @@ module.exports = (app, passport) => {
 		controllers.analytics.application
 	);
 
+	app.get('/api/*', [], controllers.static.apiError);
+
 	// Render React page
 	app.get('/*', [], controllers.static.getAll);
 };

--- a/frontend/Routes.js
+++ b/frontend/Routes.js
@@ -23,7 +23,7 @@ const Routes = () => {
 				<AuthGuard path="/programs" exact component={Programs} />
 				<AuthGuard path="/students" exact component={Students} />
 				<AuthGuard path="/students/:id" exact component={StudentShow} />
-				<AuthGuard path="/logout" exact component={LogoutPage} />
+				<Route path="/logout" exact component={LogoutPage} />
 				<Route path="*" component={NotFound} />
 			</Switch>
 		</div>


### PR DESCRIPTION
Currently the API will return the HTML template instead of a 404 error code. This remedies that.